### PR TITLE
torch._six changed to torch

### DIFF
--- a/src/optim/optimizer.py
+++ b/src/optim/optimizer.py
@@ -3,7 +3,7 @@ import torch
 import numpy as np
 import types
 import math
-from torch._six import inf
+from torch import inf
 from functools import wraps
 import warnings
 import weakref


### PR DESCRIPTION
torch._six creates issues with torch cuda and google collab, while it can be simply replaced with torch instead and it also works in normal torch versions.
**Bellow is the error reproduced:-**
![torch_six](https://github.com/Deepayan137/Adapting-OCR/assets/46810093/95ad7f5e-5bfb-459c-9839-6852a2842f50)
